### PR TITLE
Remove Rails gem dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     graphiti-rails (0.2.3)
       graphiti (~> 1.2)
-      rails (>= 5.0)
+      railties (>= 5.0)
       rescue_registry (~> 0.2.1)
 
 GEM
@@ -218,6 +218,7 @@ DEPENDENCIES
   kramdown-parser-gfm
   pry
   pry-byebug
+  rails (>= 5.0)
   responders
   rouge
   rspec-rails

--- a/graphiti-rails.gemspec
+++ b/graphiti-rails.gemspec
@@ -27,9 +27,10 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "graphiti", "~> 1.2"
   spec.add_dependency "rescue_registry", "~> 0.2.1"
-  spec.add_dependency "rails", ">= 5.0"
+  spec.add_dependency "railties", ">= 5.0"
 
   spec.add_development_dependency "sqlite3"
+  spec.add_development_dependency "rails", ">= 5.0"
   spec.add_development_dependency "rspec-rails"
   spec.add_development_dependency "graphiti_spec_helpers", "~> 1.0"
   spec.add_development_dependency "kaminari"


### PR DESCRIPTION
Problem:
Rails 5 was added as a dependency in gemspec. This restricted use of `graphiti-rails` gem in project where whole rails gem suit was not used.

If some project only uses ActionPack and `ActiveSupport` then including `graphiti-rails` results in loading all of the Rails gem suit (`ActiveRecord` etc.)

Solution:
Since graphiti-rails is dependant on 1) `actionpack` 2) `activesupport` and 3) `railties` only. We can safely remove `rails` from gemspec and add these three specific gems as dependancy